### PR TITLE
working on typo tokens (WIP)

### DIFF
--- a/src/core/typography.tokens.json5
+++ b/src/core/typography.tokens.json5
@@ -34,35 +34,35 @@
         }
       },
       fontSize: {
-        "small-1": {
+        'small-1': {
           value: '10px',
           type: 'dimension'
         },
-        "small-2": {
+        'small-2': {
           value: '12px',
           type: 'dimension'
         },
-        "small-3": {
+        'small-3': {
           value: '14px',
           type: 'dimension'
         },
-        "medium-1": {
+        'medium-1': {
           value: '16px',
           type: 'dimension'
         },
-        "medium-2": {
+        'medium-2': {
           value: '20px',
           type: 'dimension'
         },
-        "medium-3": {
+        'medium-3': {
           value: '24px',
           type: 'dimension'
         },
-        "large-1": {
+        'large-1': {
           value: '32px',
           type: 'dimension'
         },
-        "large-2": {
+        'large-2': {
           value: '40px',
           type: 'dimension'
         },
@@ -71,12 +71,27 @@
           type: 'dimension'
         }
       },
-      lineHeight: {
-        xxs: 1,
-        xs: 1.15,
-        sm: 1.2,
-        md: 1.35,
-        lg: 1.5
+      lineSpacing: {
+        none: {
+          value: 1.0,
+          type: 'number'
+        },
+        xs: {
+          value: 1.15,
+          type: 'number'
+        },
+        sm: {
+          value: 1.2,
+          type: 'number'
+        },
+        md: {
+          value: 1.35,
+          type: 'number'
+        },
+        lg: {
+          value: 1.5,
+          type: 'number'
+        }
       },
       letterSpacing: {
         standard: {


### PR DESCRIPTION
- [x] lineHeight
- [x] fontSize(Modular Scale?)

**LineHeight -> LineSpacing (better for naming)**
Using a t-shirt size scale with `none` as a special starting item for 100% = no added linespacing

**Fontsize**
Using the same grouped scale as for spacing from small to large with each 3 items.