### PR TITLE
Adding core font scale based on formula

### DIFF
--- a/src/core/typography.tokens.json5
+++ b/src/core/typography.tokens.json5
@@ -35,67 +35,67 @@
       },
       'font-scale': {
         comment: 'Font scale is based on a formular: stepX = fontScale[x - 1] + (parseInt((x - 2) / 4) + 1) * 2; fontScale.push(stepX), where fontScale[0] = 10',
-        '0': {
+        '1': {
           value: '10px',
           type: 'dimension'
         },
-        '1': {
+        '2': {
           value: '12px',
           type: 'dimension'
         },
-        '2': {
+        '3': {
           value: '14px',
           type: 'dimension'
         },
-        '3': {
+        '4': {
           value: '16px',
           type: 'dimension'
         },
-        '4': {
+        '5': {
           value: '18px',
           type: 'dimension'
         },
-        '5': {
+        '6': {
           value: '20px',
           type: 'dimension'
         },
-        '6': {
+        '7': {
           value: '24px',
           type: 'dimension'
         },
-        '7': {
+        '8': {
           value: '28px',
           type: 'dimension'
         },
-        '8': {
+        '9': {
           value: '32px',
           type: 'dimension'
         },
-        '9': {
+        '10': {
           value: '36px',
           type: 'dimension'
         },
-        '10': {
+        '11': {
           value: '42px',
           type: 'dimension'
         },
-        '11': {
+        '12': {
           value: '48px',
           type: 'dimension'
         },
-        '12': {
+        '13': {
           value: '54px',
           type: 'dimension'
         },
-        '13': {
+        '14': {
           value: '60px',
           type: 'dimension'
         },
-        '14': {
+        '15': {
           value: '68px',
           type: 'dimension'
         },
-        '15': {
+        '16': {
           value: '76px',
           type: 'dimension'
         }
@@ -114,7 +114,7 @@
           type: 'number'
         },
         lg: {
-          value: 1.45,
+          value: 1.5,
           type: 'number'
         }
       },

--- a/src/telekom.common.tokens.json5
+++ b/src/telekom.common.tokens.json5
@@ -51,7 +51,7 @@
         },
         type: 'textStyle'
       },
-      "heading-6": {
+      'heading-6': {
         value: {
           'font-family': '{semantic.typography.font-family.sans.value}',
           'font-size': '{semantic.typography.font-size.body.value}',
@@ -61,7 +61,7 @@
         },
         type: 'textStyle'
       },
-      "heading-5": {
+      'heading-5': {
         value: {
           'font-family': '{semantic.typography.font-family.sans.value}',
           'font-size': '{semantic.typography.font-size.callout.value}',
@@ -71,7 +71,7 @@
         },
         type: 'textStyle'
       },
-      "heading-4": {
+      'heading-4': {
         value: {
           'font-family': '{semantic.typography.font-family.sans.value}',
           'font-size': '{semantic.typography.font-size.headline-3.value}',
@@ -81,7 +81,7 @@
         },
         type: 'textStyle'
       },
-      "heading-3": {
+      'heading-3': {
         value: {
           'font-family': '{semantic.typography.font-family.sans.value}',
           'font-size': '{semantic.typography.font-size.headline-2.value}',
@@ -91,7 +91,7 @@
         },
         type: 'textStyle'
       },
-      "heading-2": {
+      'heading-2': {
         value: {
           'font-family': '{semantic.typography.font-family.sans.value}',
           'font-size': '{semantic.typography.font-size.headline-1.value}',
@@ -101,7 +101,7 @@
         },
         type: 'textStyle'
       },
-      "heading-1": {
+      'heading-1': {
         value: {
           'font-family': '{semantic.typography.font-family.sans.value}',
           'font-size': '{semantic.typography.font-size.title-3.value}',
@@ -111,7 +111,7 @@
         },
         type: 'textStyle'
       },
-      "title-2": {
+      'title-2': {
         value: {
           'font-family': '{semantic.typography.font-family.sans.value}',
           'font-size': '{semantic.typography.font-size.title-2.value}',
@@ -121,7 +121,7 @@
         },
         type: 'textStyle'
       },
-      "title-1": {
+      'title-1': {
         value: {
           'font-family': '{semantic.typography.font-family.sans.value}',
           'font-size': '{semantic.typography.font-size.title-1.value}',
@@ -130,52 +130,52 @@
           'letter-spacing': '{semantic.typography.letter-spacing.standard.value}'
         },
         type: 'textStyle'
-      },
+      }
     },
     typography: {
       'font-size': {
         footnote: {
-          value: '{core.typography.font-scale.0.value}',
-          type: 'dimension'
-        },
-        small: {
           value: '{core.typography.font-scale.1.value}',
           type: 'dimension'
         },
-        caption: {
+        small: {
           value: '{core.typography.font-scale.2.value}',
           type: 'dimension'
         },
-        body: {
+        caption: {
           value: '{core.typography.font-scale.3.value}',
           type: 'dimension'
         },
-        callout: {
-          value: '{core.typography.font-scale.5.value}',
+        body: {
+          value: '{core.typography.font-scale.4.value}',
           type: 'dimension'
         },
-        'headline-3': {
+        callout: {
           value: '{core.typography.font-scale.6.value}',
           type: 'dimension'
         },
+        'headline-3': {
+          value: '{core.typography.font-scale.7.value}',
+          type: 'dimension'
+        },
         'headline-2': {
-          value: '{core.typography.font-scale.8.value}',
+          value: '{core.typography.font-scale.9.value}',
           type: 'dimension'
         },
         'headline-1': {
-          value: '{core.typography.font-scale.10.value}',
+          value: '{core.typography.font-scale.11.value}',
           type: 'dimension'
         },
         'title-3': {
-          value: '{core.typography.font-scale.12.value}',
+          value: '{core.typography.font-scale.13.value}',
           type: 'dimension'
         },
         'title-2': {
-          value: '{core.typography.font-scale.14.value}',
+          value: '{core.typography.font-scale.15.value}',
           type: 'dimension'
         },
         'title-1': {
-          value: '{core.typography.font-scale.15.value}',
+          value: '{core.typography.font-scale.16.value}',
           type: 'dimension'
         }
       },


### PR DESCRIPTION
## Missing
- [x] font sizes as semantic tokens
- [x] font styles as semantic tokens
- [x] text-styles **body** which one is the best line-height? Do we really need short and long body styles?
         -> Removed body long and used 1.45 for all body. Having two body line-heights is very hard to use within components especially without container queries.
-----
Before the font sizes seemed to be arbitrarily chosen. This is problematic when a new font sizes needs to be added.

With this PR the font sizes are based on a formula while still preserving as much of the current scale as possible.
This formula needs to be documented still.

The formula is implemented here: https://codepen.io/lukasoppermann/pen/eYEGQPB?editors=1111

### Formula
```js
const steps = 15
const scale = [10] // -> scale₀ is set to 10 -> the starting point of our scale is 10px

for (let i = 1; i <= steps; i++) {
  const nextStep = scale[(i-1)] + (parseInt((i-2)/4)+1)*2
  scale.push(nextStep)
}
```

This means the next step in the scale is the `value of the last step` + ( the integer value of `(i-2)/4)` + `1` multiplied by `2`).
