### PR TITLE
refactor: improve names in Figma JSON output

### DIFF
--- a/config/build.js
+++ b/config/build.js
@@ -8,8 +8,8 @@ const PREFIX = 'scl';
 const OUTPUT_PATH = 'build/';
 const SOURCE_PATH = 'src/';
 
-const FIGMA_KEY_LIGHT = 'light';
-const FIGMA_KEY_DARK = 'dark';
+const FIGMA_KEY_LIGHT = 'Light';
+const FIGMA_KEY_DARK = 'Dark';
 
 /**
  * This is WIP, we'll split it out in different files as we make progress.


### PR DESCRIPTION
This PR adds:
- [x] human readable names to the Figma JSON output
- [x] a shadow transform in preparation to handle colors (if needed)

Remarks:
- "light" and "dark" top level keys should remain lowercase, right?
- with the current case transform rules, `ui` will end up being `Ui`, is that what we want, or do we want to "hard-code" transforming `Ui` to `UI`