### PR TITLE
Sketch specific text style json

### DIFF
--- a/src/semantic/text-styles.sketch.tokens.json5
+++ b/src/semantic/text-styles.sketch.tokens.json5
@@ -1,6 +1,6 @@
 {
   "text-style": {
-    footnoteNew: {
+    footnote: {
       value: {
         "font-family": "{text-style.footnote.value.font-family}",
         "font-size": "{typography.font-size.footnote.value}",

--- a/src/semantic/text-styles.sketch.tokens.json5
+++ b/src/semantic/text-styles.sketch.tokens.json5
@@ -1,0 +1,145 @@
+{
+  "text-style": {
+    footnoteNew: {
+      value: {
+        "font-family": "{text-style.footnote.value.font-family}",
+        "font-size": "{typography.font-size.footnote.value}",
+        "font-weight": "{typography.font-weight.regular.value}",
+        "line-spacing": "{typography.line-spacing.tight.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+        color: "{color.Text-&-Icon.Standard}"
+      },
+      type: "textStyle",
+    },
+    small: {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.small.value}",
+        "font-weight": "{typography.font-weight.medium.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    caption: {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.caption.value}",
+        "font-weight": "{typography.font-weight.regular.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    body: {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.body.value}",
+        "font-weight": "{typography.font-weight.regular.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "body-bold": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.body.value}",
+        "font-weight": "{typography.font-weight.bold.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    callout: {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.callout.value}",
+        "font-weight": "{typography.font-weight.regular.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "heading-6": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.body.value}",
+        "font-weight": "{typography.font-weight.bold.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "heading-5": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.callout.value}",
+        "font-weight": "{typography.font-weight.extra-bold.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "heading-4": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.headline-3.value}",
+        "font-weight": "{typography.font-weight.extra-bold.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "heading-3": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.headline-2.value}",
+        "font-weight": "{typography.font-weight.extra-bold.value}",
+        "line-spacing": "{typography.line-spacing.standard.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "heading-2": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.headline-1.value}",
+        "font-weight": "{typography.font-weight.extra-bold.value}",
+        "line-spacing": "{typography.line-spacing.tight.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "heading-1": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.title-3.value}",
+        "font-weight": "{typography.font-weight.extra-bold.value}",
+        "line-spacing": "{typography.line-spacing.extra-tight.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "title-2": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.title-2.value}",
+        "font-weight": "{typography.font-weight.extra-bold.value}",
+        "line-spacing": "{typography.line-spacing.extra-tight.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+    "title-1": {
+      value: {
+        "font-family": "{typography.font-family.sans.value}",
+        "font-size": "{typography.font-size.title-1.value}",
+        "font-weight": "{typography.font-weight.extra-bold.value}",
+        "line-spacing": "{typography.line-spacing.extra-tight.value}",
+        "letter-spacing": "{typography.letter-spacing.standard.value}",
+      },
+      type: "textStyle",
+    },
+  },
+}


### PR DESCRIPTION
It is a bit more complicated than expected.

@acstll do you have an idea?

Since we need to add colors, this means text styles now have to be dark & light mode. :(

I would like to inherit the settings from the default text styles.
Maybe we can add a function that does the followig:

- take a color & a text style token
- merge them together and create dark & light variations
- automatically add left, center & right variations

What do you think? Than in the json for sketch we would have another custom property like this:
```js
footnote: {
  value: {
    "text-style": "{text-style.footnote.value.font-family}",
    "color": "{color.Text-&-Icon.Standard}"
  },
  type: "sketch-textStyle",
},
```