### PR TITLE
Add new docs-json output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ public
 dist/css/
 dist/js/
 dist/sketch/
+dist/docs-json/
 dist/telekom/css/
 dist/telekom/js/
 dist/telekom/sketch/
+dist/telekom/docs-json/

--- a/change/@telekom-design-tokens-9511bbf6-0d86-4936-9c83-324faf8d1a49.json
+++ b/change/@telekom-design-tokens-9511bbf6-0d86-4936-9c83-324faf8d1a49.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add new docs-json build output",
+  "packageName": "@telekom/design-tokens",
+  "email": "ac@iconstorm.com",
+  "dependentChangeType": "patch"
+}

--- a/config/build.js
+++ b/config/build.js
@@ -17,6 +17,7 @@ const configs = [
   require('./js.config'),
   require('./figma.config'),
   require('./sketch.config'),
+  require('./docs-json.config'),
 ];
 
 configs.forEach((config) => StyleDictionary.extend(config).buildAllPlatforms());

--- a/config/css.config.js
+++ b/config/css.config.js
@@ -10,7 +10,6 @@
 
 const fs = require('fs-extra');
 const StyleDictionary = require('style-dictionary');
-const {} = require('./shared');
 
 const { PREFIX, OUTPUT_PATH, OUTPUT_BASE_FILENAME } = process.env;
 const WHITELABEL = process.env.WHITELABEL !== 'false';

--- a/config/docs-json.config.js
+++ b/config/docs-json.config.js
@@ -1,0 +1,98 @@
+/**
+ * Telekom Design Tokens https://github.com/telekom/design-tokens
+ *
+ * Copyright (c) 2021 Lukas Oppermann and contributors, Deutsche Telekom AG
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+const StyleDictionary = require('style-dictionary');
+const pick = require('lodash/pick');
+const camelCase = require('lodash/camelCase');
+const { humanCase } = require('./shared');
+
+const { PREFIX, OUTPUT_PATH, OUTPUT_BASE_FILENAME } = process.env;
+const WHITELABEL = process.env.WHITELABEL !== 'false';
+
+// Use custom 'name/cti/kebab2' plus 'color/alpha'
+const cssTransformGroup = [
+  'attribute/cti',
+  'name/cti/kebab2',
+  'time/seconds',
+  'content/icon',
+  'size/rem',
+  'color/alpha',
+  'color/css',
+];
+
+StyleDictionary.registerFormat({
+  name: 'json/docs',
+  formatter: function ({ dictionary }) {
+    const output = {
+      tokens: dictionary.allTokens.map(getDocsShape()),
+    };
+    return JSON.stringify(output, null, 2);
+  },
+});
+
+/**
+ * {
+ *   name: 'Link / Hovered',
+ *   section: 'Text & Icon',
+ *   cssVariableName: '--telekom-color-text-and-icon-standard',
+ *   javascriptVariableName: 'color.foo.bar',
+ *   value: '#000000',
+ *   comment: '...'
+ * },
+ */
+function getDocsShape() {
+  return (token) => {
+    return {
+      ...pick(token, ['path', 'value', 'comment']),
+      category: humanCase(token.path[0]),
+      section: humanCase(token.path[1]),
+      name: humanCase(token.path.slice(1).map(humanCase).join(' / ')),
+      cssVariableName: `--${token.name}`,
+      jsPathName: token.path.map(camelCase).join('.'),
+    };
+  };
+}
+
+module.exports = {
+  include: ['src/core/**/*.json5'],
+  source: [
+    ...(WHITELABEL === false ? ['src/telekom/core/**.json5'] : []),
+    'src/semantic/**/*.json5',
+  ],
+  platforms: {
+    css: {
+      transforms: ['mode-light', ...cssTransformGroup, 'shadow/css'],
+      prefix: PREFIX,
+      buildPath: OUTPUT_PATH + 'docs-json/',
+      files: [
+        {
+          destination: OUTPUT_BASE_FILENAME + '.light.json',
+          format: 'json/docs',
+          filter: (token) =>
+            token.path[0] !== 'core' && token.type !== 'textStyle',
+        },
+      ],
+    },
+    cssDark: {
+      transforms: ['mode-dark', ...cssTransformGroup, 'shadow/css'],
+      prefix: PREFIX,
+      buildPath: OUTPUT_PATH + 'docs-json/',
+      files: [
+        {
+          destination: OUTPUT_BASE_FILENAME + '.dark.json',
+          format: 'json/docs',
+          filter: (token) =>
+            token.path[0] !== 'core' &&
+            token.original.value?.dark != null &&
+            token.type !== 'textStyle',
+        },
+      ],
+    },
+  },
+};

--- a/config/docs-json.config.js
+++ b/config/docs-json.config.js
@@ -66,7 +66,7 @@ module.exports = {
     'src/semantic/**/*.json5',
   ],
   platforms: {
-    css: {
+    docsJsonLight: {
       transforms: ['mode-light', ...cssTransformGroup, 'shadow/css'],
       prefix: PREFIX,
       buildPath: OUTPUT_PATH + 'docs-json/',
@@ -79,7 +79,7 @@ module.exports = {
         },
       ],
     },
-    cssDark: {
+    docsJsonDark: {
       transforms: ['mode-dark', ...cssTransformGroup, 'shadow/css'],
       prefix: PREFIX,
       buildPath: OUTPUT_PATH + 'docs-json/',

--- a/src/semantic/color.tokens.json5
+++ b/src/semantic/color.tokens.json5
@@ -429,7 +429,7 @@
             },
           },
         },
-      }
+      },
     },
     ui: {
       comment: "UI colors are used to create ui elements like dividers, checkboxes, buttons, etc.",

--- a/src/semantic/typography.tokens.json5
+++ b/src/semantic/typography.tokens.json5
@@ -79,7 +79,7 @@
       },
     },
     "line-spacing": {
-      "none": {
+      none: {
         comment: "Use for single line in ui elements",
         value: "{core.typography.line-spacing.none.value}",
         type: "number",


### PR DESCRIPTION
Useful for building documentation (e.g. Storybook).

Features the following shape: 

```json
{
  "path": ["color", "background", "canvas"],
  "value": "#ffffff",
  "comment": "Use as the background for your product (app, website, etc.)",
  "category": "Color",
  "section": "Background",
  "name": "Background / Canvas",
  "cssVariableName": "--telekom-color-background-canvas",
  "jsPathName": "color.background.canvas"
}
```