### PR TITLE
Refactor CSS output to use `prefers-color-scheme` media query

### DIFF
--- a/change/@telekom-design-tokens-04e777ef-c644-4082-8895-2331d93d5240.json
+++ b/change/@telekom-design-tokens-04e777ef-c644-4082-8895-2331d93d5240.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Restructure CSS output file to include prefers-color-scheme media query",
+  "packageName": "@telekom/design-tokens",
+  "email": "ac@iconstorm.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/light-and-dark-mode.md
+++ b/docs/light-and-dark-mode.md
@@ -41,3 +41,25 @@ Now all your desings should be updated the use the other mode.
 
 ### Figma (beta)
 tbd
+
+## For Developers
+Dark mode is included in Scale from version `3.0.0-rc.1`. It leverages CSS variables to allow changing modes. By default, the mode will be set to match the operating system preferences, via the `prefers-color-scheme` media query.
+
+Alternatively, modes can be set via the `data-mode` attribute. The value must be either `light` or `dark`. It's recommended to do this in the `body`, e.g. `<body data-mode="light">`, though it's possible to also switch only a specific part of the page. Setting the `data-mode` attribute will override the system preferences.
+
+### Adding a switch
+
+A switch can be built into the UI with a bit of JavaScript, to set the `data-mode` attribute accordingly. The following snippet should serve as an illustration:
+
+```js
+const element = document.querySelector('.mode-switch')
+
+element.addEventListener('click', function switchMode() {
+  const isDark = document.body.dataset.mode === 'dark'
+  document.body.dataset.mode = isDark ? 'light' : 'dark'
+})
+```
+
+### Dark mode only
+
+For dark-only apps, setting the `data-mode` attribute to `dark` should be enough, e.g. `<body data-mode="dark">`.

--- a/docs/light-and-dark-mode.md
+++ b/docs/light-and-dark-mode.md
@@ -43,9 +43,13 @@ Now all your desings should be updated the use the other mode.
 tbd
 
 ## For Developers
-Dark mode is included in Scale from version `3.0.0-rc.1`. It leverages CSS variables to allow changing modes. By default, the mode will be set to match the operating system preferences, via the `prefers-color-scheme` media query.
+Dark mode is included in Scale from version `3.0.0-rc.1`. It leverages CSS variables to allow changing modes.
 
-Alternatively, modes can be set via the `data-mode` attribute. The value must be either `light` or `dark`. It's recommended to do this in the `body`, e.g. `<body data-mode="light">`, though it's possible to also switch only a specific part of the page. Setting the `data-mode` attribute will override the system preferences.
+By default, the mode will be set to match the operating system preferences, via the `prefers-color-scheme` media query.
+
+Alternatively, modes can be set via the `data-mode` attribute. The value must be either `light` or `dark`. It's recommended to do this in the `body`, e.g. `<body data-mode="light">`, though it's possible to also switch only a specific part of the page. 
+
+Setting the `data-mode` attribute will override the system preferences.
 
 ### Adding a switch
 
@@ -60,6 +64,10 @@ element.addEventListener('click', function switchMode() {
 })
 ```
 
-### Dark mode only
+### Disabling automatic switching
 
-For dark-only apps, setting the `data-mode` attribute to `dark` should be enough, e.g. `<body data-mode="dark">`.
+If you want your app to be in either light or dark mode regardless of the user's system preferences, set the `data-mode` attribute to the desired mode:
+
+```html
+<body data-mode="light">
+```

--- a/docs/light-and-dark-mode.md
+++ b/docs/light-and-dark-mode.md
@@ -64,6 +64,13 @@ element.addEventListener('click', function switchMode() {
 })
 ```
 
+In JavaScript, you can check and monitor the system preference via the [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) method.
+
+```js
+const mq = window.matchMedia('(prefers-color-scheme: dark)')
+const isDark = mq.matches
+```
+
 ### Disabling automatic switching
 
 If you want your app to be in either light or dark mode regardless of the user's system preferences, set the `data-mode` attribute to the desired mode:

--- a/src/core/color.tokens.json5
+++ b/src/core/color.tokens.json5
@@ -115,7 +115,7 @@
         "1700": {
           value: "#2b2b2d",
           type: "color",
-        }, 
+        },
         "1800": {
           value: "#242426",
           type: "color",
@@ -127,15 +127,15 @@
         "2000": {
           value: "#151517",
           type: "color",
-        }, 
+        },
         "2100": {
           value: "#0e0e0f",
           type: "color",
-        },   
+        },
         "2200": {
           value: "#000000",
           type: "color",
-        },                                                                         
+        },
       },
       brown: {
         "0": {

--- a/src/semantic/color.tokens.json5
+++ b/src/semantic/color.tokens.json5
@@ -553,7 +553,7 @@
               },
               dark: {
                 color: "{core.color.grey.0}",
-                alpha: 0.40,
+                alpha: 0.4,
               },
             },
             type: "color",


### PR DESCRIPTION
And update docs —add developer section— in `docs/light-and-dark-mode.md`.