### PR TITLE
Add text-style tokens in CSS

### DIFF
--- a/change/@telekom-design-tokens-444cbf72-b054-4e52-93a6-98bee53ea900.json
+++ b/change/@telekom-design-tokens-444cbf72-b054-4e52-93a6-98bee53ea900.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add text-style tokens in CSS",
+  "packageName": "@telekom/design-tokens",
+  "email": "ac@iconstorm.com",
+  "dependentChangeType": "patch"
+}

--- a/config/css.config.js
+++ b/config/css.config.js
@@ -15,11 +15,6 @@ const pick = require('lodash/pick');
 const { PREFIX, OUTPUT_PATH, OUTPUT_BASE_FILENAME } = process.env;
 const WHITELABEL = process.env.WHITELABEL !== 'false';
 
-/*
-  TODO
-  - [ ] text styles: split into separate variables, plus maybe add css classes?
-*/
-
 // Use custom 'name/cti/kebab2' plus 'color/alpha'
 const cssTransformGroup = [
   'attribute/cti',
@@ -29,6 +24,7 @@ const cssTransformGroup = [
   'size/rem',
   'color/alpha',
   'color/css',
+  'text-style/css'
 ];
 
 StyleDictionary.registerAction({
@@ -91,7 +87,7 @@ module.exports = {
           destination: OUTPUT_BASE_FILENAME + '.light.json',
           format: 'json/flat',
           filter: (token) =>
-            token.path[0] !== 'core' && token.type !== 'textStyle',
+            token.path[0] !== 'core',
         },
       ],
     },
@@ -105,8 +101,7 @@ module.exports = {
           format: 'json/flat',
           filter: (token) =>
             token.path[0] !== 'core' &&
-            token.original.value?.dark != null &&
-            token.type !== 'textStyle',
+            token.original.value?.dark != null,
         },
       ],
       actions: ['bundle_css'],

--- a/config/shared.js
+++ b/config/shared.js
@@ -246,6 +246,30 @@ StyleDictionary.registerTransform({
   },
 });
 
+/**
+ * Text styles for CSS using the `font` shorthand
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font
+ * 
+ * it must include values for: <font-size>, <font-family>
+ * it may optionally include values for: <font-style>, <font-variant>, <font-weight>, <font-stretch>, <line-height>
+ * 
+ * - font-style, font-variant and font-weight must precede font-size
+ * - font-variant may only specify the values defined in CSS 2.1, that is normal and small-caps
+ * - font-stretch may only be a single keyword value.
+ * - line-height must immediately follow font-size, preceded by "/", like this: "16px/3"
+ * - font-family must be the last value specified.
+ */
+ StyleDictionary.registerTransform({
+  type: 'value',
+  name: 'text-style/css',
+  transitive: true,
+  matcher: (token) => token.path[0] === 'text-style',
+  transformer: function (token) {
+    const x = token.value
+    return `${x['font-weight']} ${x['font-size']}/${x['line-spacing']} ${x['font-family']}`;
+  },
+});
+
 module.exports = {
   FIGMA_KEY_LIGHT,
   FIGMA_KEY_DARK,


### PR DESCRIPTION
This add text style tokens in the CSS output (`--telekom-text-style-`), missing until now.

The output looks like this:

```css
--telekom-text-style-footnote: 400 0.625rem/1.2 TeleNeoWeb, sans-serif;
--telekom-text-style-small: 500 0.75rem/1.35 TeleNeoWeb, sans-serif;
--telekom-text-style-small-bold: 700 0.75rem/1.35 TeleNeoWeb, sans-serif;
--telekom-text-style-caption: 400 0.875rem/1.4 TeleNeoWeb, sans-serif;
--telekom-text-style-caption-bold: 700 0.875rem/1.4 TeleNeoWeb, sans-serif;
--telekom-text-style-body: 400 1rem/1.4 TeleNeoWeb, sans-serif;
--telekom-text-style-body-bold: 700 1rem/1.4 TeleNeoWeb, sans-serif;
--telekom-text-style-ui: 500 1rem/1 TeleNeoWeb, sans-serif;
--telekom-text-style-ui-bold: 700 1rem/1 TeleNeoWeb, sans-serif;
--telekom-text-style-lead-text: 400 1.25rem/1.4 TeleNeoWeb, sans-serif;
--telekom-text-style-heading-6: 700 1rem/1.4 TeleNeoWeb, sans-serif;
--telekom-text-style-heading-5: 800 1.25rem/1.4 TeleNeoWeb, sans-serif;
--telekom-text-style-heading-4: 800 1.5rem/1.35 TeleNeoWeb, sans-serif;
--telekom-text-style-heading-3: 800 2rem/1.25 TeleNeoWeb, sans-serif;
--telekom-text-style-heading-2: 800 2.625rem/1.15 TeleNeoWeb, sans-serif;
--telekom-text-style-heading-1: 800 3.375rem/1.2 TeleNeoWeb, sans-serif;
--telekom-text-style-title-2: 800 4.25rem/1.15 TeleNeoWeb, sans-serif;
--telekom-text-style-title-1: 800 4.75rem/1.15 TeleNeoWeb, sans-serif;
```

Fixes #108 