### PR TITLE
adding yellow token to additional

### DIFF
--- a/src/core/color.tokens.json5
+++ b/src/core/color.tokens.json5
@@ -703,6 +703,56 @@
           type: "color",
         },
       },
+      yellow: {
+        "0": {
+          value: "#fffde6",
+          type: "color",
+        },
+        "100": {
+          value: "#fcf3b4",
+          type: "color",
+        },
+        "200": {
+          value: "#f9e785",
+          type: "color",
+        },
+        "300": {
+          value: "#f7d95d",
+          type: "color",
+        },
+        "400": {
+          value: "#f4ca3e",
+          type: "color",
+        },
+        "500": {
+          value: "#f1bb27",
+          type: "color",
+        },
+        "600": {
+          value: "#eeac17",
+          type: "color",
+        },
+        "700": {
+          value: "#eb9e0b",
+          type: "color",
+        },
+        "800": {
+          value: "#e89204",
+          type: "color",
+        },
+        "900": {
+          value: "#e68600",
+          type: "color",
+        },
+        tint: {
+          value: "#FDF7E8",
+          type: "color",
+        },
+        shade: {
+          value: "#302205",
+          type: "color",
+        },
+      },
     },
   },
 }

--- a/src/semantic/color.tokens.json5
+++ b/src/semantic/color.tokens.json5
@@ -2070,9 +2070,9 @@
           },
         },
       },
-      olive: {
+      yellow: {
         "0": {
-          value: "{core.color.olive.0}",
+          value: "{core.color.yellow.0}",
           type: "color",
           extensions: {
             telekom: {
@@ -2083,7 +2083,7 @@
           },
         },
         "100": {
-          value: "{core.color.olive.100}",
+          value: "{core.color.yellow.100}",
           type: "color",
           extensions: {
             telekom: {
@@ -2094,7 +2094,7 @@
           },
         },
         "200": {
-          value: "{core.color.olive.200}",
+          value: "{core.color.yellow.200}",
           type: "color",
           extensions: {
             telekom: {
@@ -2105,7 +2105,7 @@
           },
         },
         "300": {
-          value: "{core.color.olive.300}",
+          value: "{core.color.yellow.300}",
           type: "color",
           extensions: {
             telekom: {
@@ -2116,7 +2116,7 @@
           },
         },
         "400": {
-          value: "{core.color.olive.400}",
+          value: "{core.color.yellow.400}",
           type: "color",
           extensions: {
             telekom: {
@@ -2127,7 +2127,7 @@
           },
         },
         "500": {
-          value: "{core.color.olive.500}",
+          value: "{core.color.yellow.500}",
           type: "color",
           extensions: {
             telekom: {
@@ -2138,7 +2138,7 @@
           },
         },
         "600": {
-          value: "{core.color.olive.600}",
+          value: "{core.color.yellow.600}",
           type: "color",
           extensions: {
             telekom: {
@@ -2149,7 +2149,7 @@
           },
         },
         "700": {
-          value: "{core.color.olive.700}",
+          value: "{core.color.yellow.700}",
           type: "color",
           extensions: {
             telekom: {
@@ -2160,7 +2160,7 @@
           },
         },
         "800": {
-          value: "{core.color.olive.800}",
+          value: "{core.color.yellow.800}",
           type: "color",
           extensions: {
             telekom: {
@@ -2171,7 +2171,7 @@
           },
         },
         "900": {
-          value: "{core.color.olive.900}",
+          value: "{core.color.yellow.900}",
           type: "color",
           extensions: {
             telekom: {
@@ -2182,7 +2182,7 @@
           },
         },
         tint: {
-          value: "{core.color.olive.tint}",
+          value: "{core.color.yellow.tint}",
           type: "color",
           extensions: {
             telekom: {
@@ -2193,7 +2193,7 @@
           },
         },
         shade: {
-          value: "{core.color.olive.shade}",
+          value: "{core.color.yellow.shade}",
           type: "color",
           extensions: {
             telekom: {


### PR DESCRIPTION
This PR adds yellow to the additional colors, you can see the live version of the [yellow in colorbox](https://colorbox.io/?c0=%26p%24s%24%3D11%26p%24h%24st%24%3D225%26p%24h%24e%24%3D230%26p%24h%24c%24%3Deqo%26p%24sa%24st%24%3D0.2%26p%24sa%24e%24%3D1%26p%24sa%24r%24%3D1%26p%24sa%24c%24%3Deqo%26p%24b%24st%24%3D1%26p%24b%24e%24%3D0.79%26p%24b%24c%24%3Deqi%26o%24n%24%3DBlue%26o%24ms%24%3D%5B%5D%26o%24ro%24%3Dcw&c1=%26p%24s%24%3D11%26p%24h%24st%24%3D30%26p%24h%24e%24%3D15%26p%24h%24c%24%3Dl%26p%24sa%24st%24%3D0.2%26p%24sa%24e%24%3D1%26p%24sa%24r%24%3D1%26p%24sa%24c%24%3Deco%26p%24b%24st%24%3D.99%26p%24b%24e%24%3D0.58%26p%24b%24c%24%3Deqti%26o%24n%24%3DOrange%26o%24ms%24%3D%5B%5D%26o%24ro%24%3Dccw&c2=%26p%24s%24%3D11%26p%24h%24st%24%3D152%26p%24h%24e%24%3D158%26p%24h%24c%24%3Dl%26p%24sa%24st%24%3D0.35%26p%24sa%24e%24%3D1%26p%24sa%24r%24%3D1.4%26p%24sa%24c%24%3Deqo%26p%24b%24st%24%3D1%26p%24b%24e%24%3D0.445%26p%24b%24c%24%3Dl%26o%24n%24%3DGreen%26o%24ms%24%3D%5B%5D%26o%24ro%24%3Dcw&c3=%26p%24s%24%3D11%26p%24h%24st%24%3D350%26p%24h%24e%24%3D360%26p%24h%24c%24%3Dl%26p%24sa%24st%24%3D0.25%26p%24sa%24e%24%3D1%26p%24sa%24r%24%3D1%26p%24sa%24c%24%3Deco%26p%24b%24st%24%3D.92%26p%24b%24e%24%3D0.3%26p%24b%24c%24%3Deqti%26o%24n%24%3DRed%26o%24ms%24%3D%5B%5D%26o%24ro%24%3Dcw&c4=%26p%24s%24%3D10%26p%24h%24st%24%3D55%26p%24h%24e%24%3D35%26p%24h%24c%24%3Dl%26p%24sa%24st%24%3D0.1%26p%24sa%24e%24%3D1%26p%24sa%24r%24%3D1%26p%24sa%24c%24%3Deqo%26p%24b%24st%24%3D1%26p%24b%24e%24%3D0.9%26p%24b%24c%24%3Dl%26o%24n%24%3DYellow%26o%24ro%24%3Dccw%26o%24ms%24%3D%5B%5D).

The text to use on yellow is black. Apart from the shade, which requires white or yellow 600 on it.

<img width="1863" alt="Screenshot 2022-05-11 at 12 53 58" src="https://user-images.githubusercontent.com/813754/167837368-b142eed2-7e80-4bb9-9088-27bc389fb4c9.png">

@JuliaBange any concerns?

@acstll do I need to run sparkle bump in the PR?