### PR TITLE
Rename typography/font-size/footnote to /badge

### DIFF
--- a/change/@telekom-design-tokens-9bb64b5a-00eb-4339-b63c-aa3de42ae108.json
+++ b/change/@telekom-design-tokens-9bb64b5a-00eb-4339-b63c-aa3de42ae108.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Rename typography.font-size.footnote to .badge",
+  "comment": "Rename typography/font-size/footnote to /badge",
   "packageName": "@telekom/design-tokens",
   "email": "ac@iconstorm.com",
   "dependentChangeType": "patch"

--- a/change/@telekom-design-tokens-9bb64b5a-00eb-4339-b63c-aa3de42ae108.json
+++ b/change/@telekom-design-tokens-9bb64b5a-00eb-4339-b63c-aa3de42ae108.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Rename typography.font-size.footnote to .badge",
+  "packageName": "@telekom/design-tokens",
+  "email": "ac@iconstorm.com",
+  "dependentChangeType": "patch"
+}

--- a/src/semantic/text-styles.tokens.json5
+++ b/src/semantic/text-styles.tokens.json5
@@ -1,9 +1,9 @@
 {
   "text-style": {
-    footnote: {
+    badge: {
       value: {
         "font-family": "{typography.font-family.sans}",
-        "font-size": "{typography.font-size.footnote}",
+        "font-size": "{typography.font-size.badge}",
         "font-weight": "{typography.font-weight.regular}",
         "line-spacing": "{core.typography.line-spacing.xs}",
         "letter-spacing": "{typography.letter-spacing.standard}",

--- a/src/semantic/typography.tokens.json5
+++ b/src/semantic/typography.tokens.json5
@@ -1,7 +1,7 @@
 {
   typography: {
     "font-size": {
-      footnote: {
+      badge: {
         value: "{core.typography.font-scale.1.value}",
         type: "dimension",
       },


### PR DESCRIPTION
A 10px font size is considered too small accessibility-wise. (We'll keep using it in the notification badge.)