### PR TITLE
Starting with component tokens for Figma

### DIFF
--- a/change/@telekom-design-tokens-41689aec-38c3-4296-a4b7-90fb6fe6a5f6.json
+++ b/change/@telekom-design-tokens-41689aec-38c3-4296-a4b7-90fb6fe6a5f6.json
@@ -1,4 +1,5 @@
 {
+  "comment": "Adapt Figma output for latest Tokens Studio (former Figma Tokens), first attempt at component tokens (Switch)",
   "type": "prerelease",
   "packageName": "@telekom/design-tokens",
   "email": "ac@iconstorm.com",

--- a/change/@telekom-design-tokens-41689aec-38c3-4296-a4b7-90fb6fe6a5f6.json
+++ b/change/@telekom-design-tokens-41689aec-38c3-4296-a4b7-90fb6fe6a5f6.json
@@ -1,0 +1,6 @@
+{
+  "type": "prerelease",
+  "packageName": "@telekom/design-tokens",
+  "email": "ac@iconstorm.com",
+  "dependentChangeType": "patch"
+}

--- a/config/figma.config.js
+++ b/config/figma.config.js
@@ -139,18 +139,26 @@ StyleDictionary.registerAction({
     const dark = JSON.parse(
       await fs.readFile(buildPath + TMP_NAME + '.dark.json')
     );
-    // All modes
+    // Everything
     await fs.writeFile(
       buildPath + OUTPUT_BASE_FILENAME + '.all.json',
       JSON.stringify(
         {
-          Theme: {
-            [FIGMA_KEY_LIGHT]: { ...light },
-            [FIGMA_KEY_DARK]: { ...dark },
-          },
           Universal: {
             ...modeless,
           },
+          [FIGMA_KEY_LIGHT]: { ...light },
+          [FIGMA_KEY_DARK]: { ...dark },
+          Component: {}, // TODO
+          '$themes': [],
+          '$metadata': {
+            tokenSetOrder: [
+              'Universal',
+              FIGMA_KEY_LIGHT,
+              FIGMA_KEY_DARK,
+              'Component',
+            ]
+          }
         },
         null,
         2
@@ -161,12 +169,7 @@ StyleDictionary.registerAction({
       buildPath + OUTPUT_BASE_FILENAME + '.light.json',
       JSON.stringify(
         {
-          Theme: {
-            [FIGMA_KEY_LIGHT]: { ...light },
-          },
-          Universal: {
-            ...modeless,
-          },
+          [FIGMA_KEY_LIGHT]: { ...light },
         },
         null,
         2
@@ -177,12 +180,7 @@ StyleDictionary.registerAction({
       buildPath + OUTPUT_BASE_FILENAME + '.dark.json',
       JSON.stringify(
         {
-          Theme: {
-            [FIGMA_KEY_DARK]: { ...dark },
-          },
-          Universal: {
-            ...modeless,
-          },
+          [FIGMA_KEY_DARK]: { ...dark },
         },
         null,
         2
@@ -206,6 +204,7 @@ module.exports = {
   source: [
     ...(WHITELABEL === false ? ['src/telekom/core/**.json5'] : []),
     'src/semantic/**/*.json5',
+    'src/component/**/*.json5',
   ],
   platforms: {
     figmaModeless: {
@@ -218,6 +217,7 @@ module.exports = {
           filter: (token) =>
             token.path[0] !== 'core' &&
             token.path[0] !== 'motion' &&
+            token.path[0] !== 'component' &&
             !hasMode(token),
         },
       ],

--- a/src/component/switch.tokens.json5
+++ b/src/component/switch.tokens.json5
@@ -1,11 +1,9 @@
 // QUESTIONS:
 // - do we namespace "global" tokens -> "shared", "common"?
-// - is the category position OK?
+// - is the "category" position OK?
 // - "size" or "sizing" — do we need it apart from "spacing"?
 // - start using "default" for default state exclusively, instead of "standard"?
 // - CSS: do we need the "component" prefix in the token name in the output?
-// TODO:
-// - keep aliases in output! (both in Figma and CSS)
 
 {
   component: {

--- a/src/component/switch.tokens.json5
+++ b/src/component/switch.tokens.json5
@@ -1,0 +1,177 @@
+// QUESTIONS:
+// - do we namespace "global" tokens -> "shared", "common"?
+// - is the category position OK?
+// - "size" or "sizing" — do we need it apart from "spacing"?
+// - start using "default" for default state exclusively, instead of "standard"?
+// - CSS: do we need the "component" prefix in the token name in the output?
+// TODO:
+// - keep aliases in output! (both in Figma and CSS)
+
+{
+  component: {
+    switch: {
+      shared: {
+        motion: {
+          duration: {
+            value: "{motion.duration.immediate.value}",
+            type: "time",
+          },
+          easing: {
+            value: "{motion.easing.standard.value}",
+            type: "cubic-bezier",
+          },
+        },
+        size: {
+          height: {
+            value: "{spacing.unit.x8.value}",
+            type: "dimension",
+          },
+        },
+        radius: {
+          value: "{radius.circle.value}",
+          type: "dimension",
+        },
+      },
+      toggle: {
+        color: {
+          background: {
+            default: {
+              value: "{color.ui.faint.value}",
+              type: "color",
+            },
+            hovered: {
+              value: "{color.ui.state-fill.hovered.value}",
+              type: "color",
+            },
+            pressed: {
+              value: "{color.ui.state-fill.pressed.value}",
+              type: "color",
+            },
+            disabled: {
+              value: "{color.ui.disabled.value}",
+              type: "color",
+            },
+            checked: {
+              default: {
+                value: "{color.primary.standard.value}",
+                type: "color",
+              },
+              hovered: {
+                value: "{color.primary.hovered.value}",
+                type: "color",
+              },
+              pressed: {
+                value: "{color.primary.pressed.value}",
+                type: "color",
+              },
+              disabled: {
+                value: "{color.ui.disabled.value}",
+                type: "color",
+              },
+            },
+          },
+        },
+      },
+      // called "io-text" in code
+      "toggle-label": {
+        "text-style": {
+          value: "{text-style.small-bold.value}",
+          type: "textStyle",
+        },
+        color: {
+          text: {
+            default: {
+              value: "{color.text-&-icon.standard.value}",
+              type: "color",
+            },
+            checked: {
+              value: "{color.text-&-icon.white.standard.value}",
+              type: "color",
+            },
+          },
+        },
+      },
+      thumb: {
+        spacing: {
+          offset: {
+            value: "{spacing.unit.x05.value}",
+            type: "dimension",
+            description: "The offset of the thumb from the edge of the toggle.",
+          },
+        },
+        color: {
+          background: {
+            default: {
+              value: "{color.ui.white.value}",
+              type: "color",
+            },
+            disabled: {
+              value: "{color.ui.faint.value}",
+              type: "color",
+            },
+          },
+          border: {
+            value: "#0000000A",
+            type: "color",
+          },
+        },
+        shadow: {
+          value: [
+            {
+              x: 0,
+              y: 0,
+              blur: 2,
+              spread: 0,
+              color: {
+                color: "{core.color.black}",
+                alpha: 0.24,
+              },
+              type: "dropShadow",
+            },
+            {
+              x: 0,
+              y: 2,
+              blur: 4,
+              spread: 0,
+              color: {
+                color: "{core.color.black}",
+                alpha: 0.24,
+              },
+              type: "dropShadow",
+            },
+            {
+              x: 0,
+              y: 4,
+              blur: 12,
+              spread: 0,
+              color: {
+                color: "{core.color.black}",
+                alpha: 0.26,
+              },
+              type: "dropShadow",
+            },
+          ],
+          type: "shadow",
+        },
+        "line-weight": {
+          border: {
+            value: "{line-weight.standard.value}",
+            type: "dimension",
+          },
+        },
+      },
+      label: {
+        "text-style": {
+          value: "{text-style.ui.value}",
+          type: "textStyle",
+        },
+        spacing: {
+          "inline-start": {
+            value: "{spacing.unit.x2.value}",
+            type: "dimension",
+          },
+        },
+      },
+    },
+  },
+}

--- a/src/component/switch.tokens.json5
+++ b/src/component/switch.tokens.json5
@@ -13,22 +13,22 @@
       shared: {
         motion: {
           duration: {
-            value: "{motion.duration.immediate.value}",
+            value: "%motion.duration.immediate%",
             type: "time",
           },
           easing: {
-            value: "{motion.easing.standard.value}",
+            value: "%motion.easing.standard%",
             type: "cubic-bezier",
           },
         },
         size: {
           height: {
-            value: "{spacing.unit.x8.value}",
+            value: "%spacing.unit.x8%",
             type: "dimension",
           },
         },
         radius: {
-          value: "{radius.circle.value}",
+          value: "%radius.circle%",
           type: "dimension",
         },
       },
@@ -36,36 +36,36 @@
         color: {
           background: {
             default: {
-              value: "{color.ui.faint.value}",
+              value: "%color.ui.faint%",
               type: "color",
             },
             hovered: {
-              value: "{color.ui.state-fill.hovered.value}",
+              value: "%color.ui.state-fill.hovered%",
               type: "color",
             },
             pressed: {
-              value: "{color.ui.state-fill.pressed.value}",
+              value: "%color.ui.state-fill.pressed%",
               type: "color",
             },
             disabled: {
-              value: "{color.ui.disabled.value}",
+              value: "%color.ui.disabled%",
               type: "color",
             },
             checked: {
               default: {
-                value: "{color.primary.standard.value}",
+                value: "%color.primary.standard%",
                 type: "color",
               },
               hovered: {
-                value: "{color.primary.hovered.value}",
+                value: "%color.primary.hovered%",
                 type: "color",
               },
               pressed: {
-                value: "{color.primary.pressed.value}",
+                value: "%color.primary.pressed%",
                 type: "color",
               },
               disabled: {
-                value: "{color.ui.disabled.value}",
+                value: "%color.ui.disabled%",
                 type: "color",
               },
             },
@@ -75,17 +75,17 @@
       // called "io-text" in code
       "toggle-label": {
         "text-style": {
-          value: "{text-style.small-bold.value}",
+          value: "%text-style.small-bold%",
           type: "textStyle",
         },
         color: {
           text: {
             default: {
-              value: "{color.text-&-icon.standard.value}",
+              value: "%color.text-&-icon.standard%",
               type: "color",
             },
             checked: {
-              value: "{color.text-&-icon.white.standard.value}",
+              value: "%color.text-&-icon.white.standard%",
               type: "color",
             },
           },
@@ -94,19 +94,19 @@
       thumb: {
         spacing: {
           offset: {
-            value: "{spacing.unit.x05.value}",
+            value: "%spacing.unit.x05%",
             type: "dimension",
-            description: "The offset of the thumb from the edge of the toggle.",
+            comment: "The offset of the thumb from the edge of the toggle.",
           },
         },
         color: {
           background: {
             default: {
-              value: "{color.ui.white.value}",
+              value: "%color.ui.white%",
               type: "color",
             },
             disabled: {
-              value: "{color.ui.faint.value}",
+              value: "%color.ui.faint%",
               type: "color",
             },
           },
@@ -155,19 +155,19 @@
         },
         "line-weight": {
           border: {
-            value: "{line-weight.standard.value}",
+            value: "%line-weight.standard%",
             type: "dimension",
           },
         },
       },
       label: {
         "text-style": {
-          value: "{text-style.ui.value}",
+          value: "%text-style.ui%",
           type: "textStyle",
         },
         spacing: {
           "inline-start": {
-            value: "{spacing.unit.x2.value}",
+            value: "%spacing.unit.x2%",
             type: "dimension",
           },
         },


### PR DESCRIPTION
- [x] first attempt at component tokens with Switch
- [x] improve Figma output to satisfy latest Tokens Studio

New shape for Figma is as follows:
```json
{
  "Universal": {},
  "Light": {},
  "Dark": {},
  "Component": {},
  "$themes": [],
  "$metadata": {
    "tokenSetOrder": [
      "Universal",
      "Light",
      "Dark",
      "Component"
    ]
  }
}
```

Also, I couldn't find a way for style-dictionary to keep the aliases without resolving them, so I came up with this custom "syntax" [replacing the curly braces with the % sign](https://github.com/telekom/design-tokens/blob/31e3b632a50d1736f480d1ea2ff90e6eec131571/src/component/switch.tokens.json5#L37). I hope I'm not doing something silly… 🙃

```diff
default: {
-  value: "{color.ui.faint}",
+  value: "%color.ui.faint%",
  type: "color",
},
```
This way we can turn `%color.ui.faint%` into `{UI.Faint}` (which is what Tokens Studio is expecting in order to keep the reference) without much trouble.