### PR TITLE
Figma: add core tokens to output

### DIFF
--- a/change/@telekom-design-tokens-c1f0355e-c5f2-4a21-9495-040341a865e7.json
+++ b/change/@telekom-design-tokens-c1f0355e-c5f2-4a21-9495-040341a865e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Improve Figma output with core tokens with refs, and $themes",
+  "packageName": "@telekom/design-tokens",
+  "email": "ac@iconstorm.com",
+  "dependentChangeType": "patch"
+}

--- a/config/figma.config.js
+++ b/config/figma.config.js
@@ -96,11 +96,14 @@ function formatJSON(allTokens, { dictionary, mode }) {
   allTokens.forEach((token) => {
     const path = token.path.map(humanCase);
     if (path.includes('Motion')) return;
+    // Keep Core in path to avoid collisions with same name tokens
+    const keepCoreInPathToAvoidCollisionsWithSameNameTokens =
+      path[0] === 'Core' && path[1] !== 'Spacing' && path[1] !== 'Radius';
     if (
       path[0] === 'Color' ||
       path[0] === 'Shadow' ||
       path[0] === 'Typography' ||
-      path[0] === 'Core'
+      keepCoreInPathToAvoidCollisionsWithSameNameTokens
     ) {
       path.shift();
     }
@@ -162,6 +165,10 @@ function getJSONValue(token, { dictionary, mode }) {
         ref = mode === 'light' ? refs[0] : refs[1];
       }
       const path = ref.path.map(humanCase);
+      // Keep Core in path to avoid collisions with same name tokens
+      if (path[1] !== 'Spacing' && path[1] !== 'Radius') {
+        path.shift();
+      }
       value = `{${path.join('.')}}`;
     }
   }

--- a/config/figma.config.js
+++ b/config/figma.config.js
@@ -173,7 +173,8 @@ function getJSONValue(token, { dictionary, mode }) {
           ...dictionary.getReferences(token.original.value.dark),
         ]
       : dictionary.getReferences(token.original.value);
-    // TODO FIXME shadow-type core tokens result in refs.length === 0
+    // ! "shadow" type core tokens result in refs.length === 0
+    // (color modifiers are not supported within shadow tokens)
     if (refs.length > 0) {
       let ref = refs[0];
       if (typeof mode !== 'undefined' && refs.length === 2) {

--- a/config/figma.config.js
+++ b/config/figma.config.js
@@ -48,6 +48,48 @@ const categoryTypeMap = {
   font: 'fontFamilies',
 };
 
+const THEMES = [
+  {
+    id: '0efe74c81045c31912f3f25ceccbb79a4021d482',
+    name: 'Telekom',
+    $figmaStyleReferences: {},
+    selectedTokenSets: {
+      Core: 'enabled',
+    },
+    group: 'Core',
+  },
+  {
+    id: '7a9907de042ac3a05850bed823405e364006587c',
+    name: 'Values',
+    $figmaStyleReferences: {},
+    selectedTokenSets: {
+      Core: 'source',
+      Global: 'enabled',
+    },
+    group: 'Global',
+  },
+  {
+    id: 'e84d59b7aab9a411698c3781401bf695dc2d2952',
+    name: 'Light',
+    $figmaStyleReferences: {},
+    selectedTokenSets: {
+      Core: 'source',
+      Light: 'enabled',
+    },
+    group: 'Color',
+  },
+  {
+    id: 'e3dd70729694cefd558242ba5e81517f4bc0d626',
+    name: 'Dark',
+    $figmaStyleReferences: {},
+    selectedTokenSets: {
+      Core: 'source',
+      Dark: 'enabled',
+    },
+    group: 'Color',
+  },
+];
+
 function formatJSON(allTokens, { dictionary, mode }) {
   const output = {};
   deep.p = true;
@@ -200,9 +242,9 @@ StyleDictionary.registerAction({
           },
           [FIGMA_KEY_LIGHT]: { ...light },
           [FIGMA_KEY_DARK]: { ...dark },
-          $themes: [],
+          $themes: THEMES,
           $metadata: {
-            tokenSetOrder: ['Global', FIGMA_KEY_LIGHT, FIGMA_KEY_DARK],
+            tokenSetOrder: ['Core', 'Global', FIGMA_KEY_LIGHT, FIGMA_KEY_DARK],
           },
         },
         null,

--- a/src/core/typography.tokens.json5
+++ b/src/core/typography.tokens.json5
@@ -32,7 +32,7 @@
           value: 800,
           type: "number",
         },
-        "ultra": {
+        ultra: {
           value: 900,
           type: "number",
         },

--- a/src/semantic/typography.tokens.json5
+++ b/src/semantic/typography.tokens.json5
@@ -77,7 +77,7 @@
         value: "{core.typography.font-weight.extra-bold.value}",
         type: "number",
       },
-      "ultra": {
+      ultra: {
         value: "{core.typography.font-weight.ultra.value}",
         type: "number",
       },


### PR DESCRIPTION
* [x] core tokens in output
* [x] semantic use reference e.g. `{Core.Color.Black}`
* [x] light and dark mode are correct
* [x] refs [modified with alpha](https://docs.tokens.studio/tokens/color-modifiers#alpha) are handled