### PR TITLE
fix: add magenta color token for dark mode and adjust black level of one design token for sufficent contrast

### DIFF
--- a/output/telekom/figma/telekom-design-tokens.all.json
+++ b/output/telekom/figma/telekom-design-tokens.all.json
@@ -3641,7 +3641,7 @@
         }
       },
       "Surface": {
-        "value": "{Color.Grey.1900}",
+        "value": "{Color.Grey.2000}",
         "type": "color",
         "description": "Use as the background of elements like cards, headers, bottom bars, etc."
       },

--- a/output/telekom/figma/telekom-design-tokens.all.json
+++ b/output/telekom/figma/telekom-design-tokens.all.json
@@ -15,6 +15,11 @@
           "type": "color",
           "description": "Defined by brand, can not be changed"
         },
+        "Standard_dark": {
+          "value": "#f61488",
+          "type": "color",
+          "description": "For dark mode with black background"
+        },
         "Dark": {
           "value": "#C00063",
           "type": "color",
@@ -3458,7 +3463,7 @@
       },
       "Primary": {
         "Standard": {
-          "value": "{Color.Brand.Standard}",
+          "value": "{Color.Brand.Standard_dark}",
           "type": "color"
         },
         "Hovered": {
@@ -3653,7 +3658,7 @@
     },
     "Primary": {
       "Standard": {
-        "value": "{Color.Brand.Standard}",
+        "value": "{Color.Brand.Standard_dark}",
         "type": "color"
       },
       "Hovered": {

--- a/output/telekom/figma/telekom-design-tokens.dark.json
+++ b/output/telekom/figma/telekom-design-tokens.dark.json
@@ -231,7 +231,7 @@
       }
     },
     "Surface": {
-      "value": "{Color.Grey.1900}",
+      "value": "{Color.Grey.2000}",
       "type": "color",
       "description": "Use as the background of elements like cards, headers, bottom bars, etc."
     },

--- a/output/telekom/figma/telekom-design-tokens.dark.json
+++ b/output/telekom/figma/telekom-design-tokens.dark.json
@@ -53,7 +53,7 @@
     },
     "Primary": {
       "Standard": {
-        "value": "{Color.Brand.Standard}",
+        "value": "{Color.Brand.Standard_dark}",
         "type": "color"
       },
       "Hovered": {
@@ -248,7 +248,7 @@
   },
   "Primary": {
     "Standard": {
-      "value": "{Color.Brand.Standard}",
+      "value": "{Color.Brand.Standard_dark}",
       "type": "color"
     },
     "Hovered": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telekom/design-tokens",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.11",
   "description": "The source of truth for Telekom's corporate brand and design",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telekom/design-tokens",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "description": "The source of truth for Telekom's corporate brand and design",
   "files": [
     "dist",

--- a/src/core/color.tokens.json5
+++ b/src/core/color.tokens.json5
@@ -14,6 +14,10 @@
           value: "#5300FF",
           type: "color",
         },
+        standard_dark: {
+          value: "#8F59FF",
+          type: "color",
+        },
         dark: {
           comment: "Brand with 15% black overlay",
           value: "#4700D9",

--- a/src/semantic/color.tokens.json5
+++ b/src/semantic/color.tokens.json5
@@ -615,7 +615,7 @@
         comment: "Use as the background of elements like cards, headers, bottom bars, etc.",
         value: {
           light: "{core.color.grey.0}",
-          dark: "{core.color.grey.1900}",
+          dark: "{core.color.grey.2000}",
         },
         type: "color",
         extensions: {

--- a/src/semantic/color.tokens.json5
+++ b/src/semantic/color.tokens.json5
@@ -121,7 +121,7 @@
         standard: {
           value: {
             light: "{core.color.brand.standard}",
-            dark: "{core.color.brand.standard}",
+            dark: "{core.color.brand.standard_dark}",
           },
           type: "color",
           extensions: {
@@ -689,7 +689,7 @@
       standard: {
         value: {
           light: "{core.color.brand.standard}",
-          dark: "{core.color.brand.standard}",
+          dark: "{core.color.brand.standard_dark}",
         },
         type: "color",
         extensions: {

--- a/src/telekom/core/color.tokens.json5
+++ b/src/telekom/core/color.tokens.json5
@@ -8,6 +8,11 @@
           value: "#e20074",
           type: "color",
         },
+        standard_dark: {
+          comment: "For dark mode with black background",
+          value: "#f61488",
+          type: "color",
+        },
         dark: {
           comment: "Brand magenta with 15% black overlay",
           value: "#C00063",


### PR DESCRIPTION
The current color code for magenta (#e20074) causes a11y-issues if used in dark mode, since the contrast ratio to a black background is too low (4.48:1).
As solution an alternative color code ("core.color.brand.standard_dark",  #f61488) was added, which is now used in design tokens like "--telekom-color-text-and-icon-primary-standard" in dark mode. The contrast ratio is now 5.37:1 with a black background.
In addition the black level of --telekom-color-background-surface had to be increased for sufficent contrast in dark mode.